### PR TITLE
Transition

### DIFF
--- a/src/atom.js
+++ b/src/atom.js
@@ -5,8 +5,8 @@ import { inMemory } from './plugins';
 export default (data : Object, createStore : Function = inMemory) => {
   const watchers = [];
 
-  const transition = (next, prev) =>
-    watchers.forEach(watcher => watcher(prev, next));
+  const transition = (...args) =>
+    watchers.forEach(watcher => watcher(...args));
 
   return {
     ...createStore(data, transition),

--- a/src/atom.js
+++ b/src/atom.js
@@ -5,10 +5,8 @@ import { inMemory } from './plugins';
 export default (data : Object, createStore : Function = inMemory) => {
   const watchers = [];
 
-  const transition = (next, prev) => {
+  const transition = (next, prev) =>
     watchers.forEach(watcher => watcher(prev, next));
-    return next;
-  };
 
   return {
     ...createStore(data, transition),

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -6,7 +6,7 @@ export const inMemory = (data : Object, transition : Function) => {
     write(fn : Function) {
       const oldState = this.read();
       const newState = fn(oldState);
-      transition(newState, oldState);
+      transition(oldState, newState);
       rootState = newState;
       return rootState;
     },
@@ -22,7 +22,7 @@ export const webStorage = ({ type, key } : Object, data : Object, transition : F
     write(fn: Function) {
       const oldState = this.read();
       const newState = fn(oldState);
-      transition(newState, oldState);
+      transition(oldState, newState);
       store.setItem(key, JSON.stringify(newState));
     },
     read() {

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -4,7 +4,10 @@ export const inMemory = (data : Object, transition : Function) => {
   let rootState = data;
   return {
     write(fn : Function) {
-      rootState = transition(fn(this.read()), this.read());
+      const oldState = this.read();
+      const newState = fn(oldState);
+      transition(newState, oldState);
+      rootState = newState;
       return rootState;
     },
     read() {
@@ -17,8 +20,10 @@ export const webStorage = ({ type, key } : Object, data : Object, transition : F
   const store = window[`${type}Storage`];
   return {
     write(fn: Function) {
-      const rootState = transition(fn(this.read()), this.read());
-      store.setItem(key, JSON.stringify(rootState));
+      const oldState = this.read();
+      const newState = fn(oldState);
+      transition(newState, oldState);
+      store.setItem(key, JSON.stringify(newState));
     },
     read() {
       return JSON.parse(store.getItem(key));


### PR DESCRIPTION
This PR swaps the argument order for `transition` in plugins, so that they are the same as watcher argument order, and makes explicit the fact that `transition` is a side-effect.

As well as standardizing arg orders, it also allows for plugins to provide custom props to watchers - for example, `watcher(oldState, newState, changePath)` for immutable-cursor, or `watcher(newState, signalString)` for a redux/cerebral implementation.