### PR TITLE
Standardize plugin behavior

### DIFF
--- a/src/plugins.js
+++ b/src/plugins.js
@@ -1,7 +1,7 @@
 /* @flow */
 
-export const inMemory = (data : Object, transition : Function) => {
-  let rootState = data;
+export const inMemory = (initial : Object, transition : Function) => {
+  let rootState = initial;
   const read = () => rootState;
   const write = (fn : Function) => {
     const oldState = read();
@@ -15,7 +15,7 @@ export const inMemory = (data : Object, transition : Function) => {
 
 export const webStorage = (
   { type, key } : Object,
-  data : Object,
+  initial : Object,
   transition : Function
 ) => {
   const store = window[`${type}Storage`];

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -2,31 +2,29 @@
 
 export const inMemory = (data : Object, transition : Function) => {
   let rootState = data;
-  return {
-    write(fn : Function) {
-      const oldState = this.read();
-      const newState = fn(oldState);
-      transition(oldState, newState);
-      rootState = newState;
-      return rootState;
-    },
-    read() {
-      return rootState;
-    },
+  const read = () => rootState;
+  const write = (fn : Function) => {
+    const oldState = read();
+    const newState = fn(oldState);
+    transition(oldState, newState);
+    rootState = newState;
+    return read();
   };
+  return { read, write };
 };
 
-export const webStorage = ({ type, key } : Object, data : Object, transition : Function) => {
+export const webStorage = (
+  { type, key } : Object,
+  data : Object,
+  transition : Function
+) => {
   const store = window[`${type}Storage`];
-  return {
-    write(fn: Function) {
-      const oldState = this.read();
-      const newState = fn(oldState);
-      transition(oldState, newState);
-      store.setItem(key, JSON.stringify(newState));
-    },
-    read() {
-      return JSON.parse(store.getItem(key));
-    },
+  const read = () => JSON.parse(store.getItem(key));
+  const write = (fn : Function) => {
+    const oldState = read();
+    const newState = fn(oldState);
+    transition(oldState, newState);
+    store.setItem(key, JSON.stringify(newState));
   };
+  return { read, write };
 };

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -15,10 +15,13 @@ export const inMemory = (initial : Object, transition : Function) => {
 
 export const webStorage = (
   { type, key } : Object,
-  initial : Object,
+  initial : Object | void,
   transition : Function
 ) => {
   const store = window[`${type}Storage`];
+  if (initial !== undefined) {
+    store.setItem(key, JSON.stringify(initial));
+  }
   const read = () => JSON.parse(store.getItem(key));
   const write = (fn : Function) => {
     const oldState = read();

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -25,6 +25,7 @@ export const webStorage = (
     const newState = fn(oldState);
     transition(oldState, newState);
     store.setItem(key, JSON.stringify(newState));
+    return read();
   };
   return { read, write };
 };

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -19,12 +19,15 @@ describe('Plugins', () => {
   describe('Web', () => {
     it('reads', () => {
       const getItem = stub().returns('{"hello":"wahey"}');
+      const setItem = spy();
       global.window = {
         localStorage: {
           getItem,
+          setItem,
         },
       };
-      const atom = createAtom('hello', webStorage.bind(null, { type: 'local', key: 'test' }));
+      const atom = createAtom('initial', webStorage.bind(null, { type: 'local', key: 'test' }));
+      expect(setItem).to.have.been.calledWithExactly('test', '"initial"');
       expect(atom.read()).to.deep.equal({ hello: 'wahey' });
     });
     it('writes', () => {
@@ -40,6 +43,19 @@ describe('Plugins', () => {
       const writeped = atom.write(() => ({ changed: 'for the better' }));
       expect(writeped).to.not.be.undefined; // eslint-disable-line no-unused-expressions
       expect(setItem).to.have.been.calledWithExactly('test', '{"changed":"for the better"}');
+    });
+    it('Use localStorage for default initial data', () => {
+      const getItem = stub().returns('{"hello":"wahey"}');
+      const setItem = spy();
+      global.window = {
+        localStorage: {
+          getItem,
+          setItem,
+        },
+      };
+      const atom = createAtom(undefined, webStorage.bind(null, { type: 'local', key: 'test' }));
+      expect(setItem).to.not.have.been.called; // eslint-disable-line no-unused-expressions
+      expect(atom.read()).to.deep.equal({ hello: 'wahey' });
     });
   });
 });

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -37,7 +37,8 @@ describe('Plugins', () => {
         },
       };
       const atom = createAtom('hello', webStorage.bind(null, { type: 'local', key: 'test' }));
-      atom.write(() => ({ changed: 'for the better' }));
+      const writeped = atom.write(() => ({ changed: 'for the better' }));
+      expect(writeped).to.not.be.undefined; // eslint-disable-line no-unused-expressions
       expect(setItem).to.have.been.calledWithExactly('test', '{"changed":"for the better"}');
     });
   });


### PR DESCRIPTION
This PR makes the webStorage plugin behave the same as the inMemory plugin on write. It also fixes an issue with the webStorage plugin, in that it ignores initial data.