### PR TITLE
Make watchers async

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "type": "git",
     "url": "https://github.com/jameshopkins/atom-store.git"
   },
-  "dependencies": {},
+  "dependencies": {
+    "setasap": "^2.0.0"
+  },
   "devDependencies": {
     "babel-cli": "^6.8.0",
     "babel-core": "^6.8.0",

--- a/src/atom.js
+++ b/src/atom.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import { inMemory } from './plugins';
+import setAsap from 'setasap';
 
 export default (data : Object, createStore : Function = inMemory) => {
   const watchers = [];
@@ -13,7 +14,8 @@ export default (data : Object, createStore : Function = inMemory) => {
   return {
     ...createStore(data, transition),
     watch(fn) {
-      watchers.push(fn);
+      const watcher = (...args) => setAsap(() => fn(...args));
+      watchers.push(watcher);
     },
   };
 };


### PR DESCRIPTION
This PR makes watchers run asynchronously.

* This will not pass the current tests, as they are written to exploit synchronous operation
* It should pass the tests in #3
* It should not interfere with the operation of dependant software, unless they're doing really weird mutative stuff with race conditions
* I haven't actually tested it, due to lazy - pending #3