### PR TITLE
Remove transform-runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": [ "es2015", "stage-0" ],
-  "plugins": [ "transform-flow-strip-types", "transform-runtime" ],
+  "plugins": [ "transform-flow-strip-types" ],
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "babel-core": "^6.8.0",
     "babel-eslint": "^6.0.4",
     "babel-plugin-transform-flow-strip-types": "^6.5.0",
-    "babel-plugin-transform-runtime": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0",
     "chai": "^3.5.0",


### PR DESCRIPTION
Atom-store is currently broken, as `transform-runtime` adds a dependency which is not included. I understand why you would have it, and considered making a PR with this dep, but it's fairly large, and the actual size difference without it is trivial (even ignoring that gzip will remove the size diff entirely):

Compiled `atom.js`, with `transform-runtime`:
`var _extends2 = require('babel-runtime/helpers/extends'); var _extends3 = _interopRequireDefault(_extends2);`

Without `transform-runtime`:
`var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };`
